### PR TITLE
don't use ioutil.ReadAll

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 )
@@ -180,8 +179,7 @@ func (r *Resource) do(method string) (*Resource, error) {
 
 	defer resp.Body.Close()
 
-	contents, _ := ioutil.ReadAll(resp.Body)
-	err = json.Unmarshal(contents, r.Api.Methods[r.Url].Response)
+	err = json.NewDecoder(resp.Body).Decode(r.Api.Methods[r.Url].Response)
 	if err != nil {
 		return r, err
 	}


### PR DESCRIPTION
Hi,

this rewrites the way the contents are read from the `resp.Body`. With `ioutil.ReadAll` you essentially throw the whole responses in memory and than consume it with `encoding/json`. With `json.NewDecoder`, the responses is consumed directly from the response so you don't have to download and allocate the whole thing in ram.

Plus: you ignored the error from `ReadAll` before.
