### PR TITLE
remove Methods and Options map from ApiStruct

### DIFF
--- a/api.go
+++ b/api.go
@@ -31,8 +31,6 @@ type BasicAuth struct {
 // No Options yet supported.
 type ApiStruct struct {
 	Base      string
-	Methods   map[string]*Resource
-	Options   map[string]bool
 	BasicAuth *BasicAuth
 	Client    *http.Client
 	Cookies   *cookiejar.Jar
@@ -44,7 +42,8 @@ func Api(url string, options ...interface{}) *Resource {
 	if !strings.HasSuffix(url, "/") {
 		url = url + "/"
 	}
-	apiInstance := &ApiStruct{Base: url, Methods: make(map[string]*Resource), BasicAuth: nil}
+
+	apiInstance := &ApiStruct{Base: url, BasicAuth: nil}
 
 	if len(options) > 0 {
 		if auth, ok := options[0].(*BasicAuth); ok {

--- a/resource.go
+++ b/resource.go
@@ -48,13 +48,13 @@ func (r *Resource) Res(options ...interface{}) *Resource {
 			url = options[0].(string)
 		}
 
-		r.Api.Methods[url] = &Resource{Url: url, Api: r.Api, Headers: http.Header{}}
+		newR := &Resource{Url: url, Api: r.Api, Headers: http.Header{}}
 
 		if len(options) > 1 {
-			r.Api.Methods[url].Response = options[1]
+			newR.Response = options[1]
 		}
 
-		return r.Api.Methods[url]
+		return newR
 	}
 	return r
 }
@@ -70,14 +70,12 @@ func (r *Resource) Id(options ...interface{}) *Resource {
 			id = strconv.Itoa(v)
 		}
 		url := r.Url + "/" + id
-		r.Api.Methods[url] = &Resource{id: id, Url: url, Api: r.Api, Headers: http.Header{}}
+		newR := &Resource{id: id, Url: url, Api: r.Api, Headers: http.Header{}, Response: &r.Response}
 
 		if len(options) > 1 {
-			r.Api.Methods[url].Response = options[1]
-		} else {
-			r.Api.Methods[url].Response = &r.Api.Methods[r.Url].Response
+			newR.Response = options[1]
 		}
-		return r.Api.Methods[url]
+		return newR
 	}
 	return r
 }
@@ -179,7 +177,7 @@ func (r *Resource) do(method string) (*Resource, error) {
 
 	defer resp.Body.Close()
 
-	err = json.NewDecoder(resp.Body).Decode(r.Api.Methods[r.Url].Response)
+	err = json.NewDecoder(resp.Body).Decode(r.Response)
 	if err != nil {
 		return r, err
 	}


### PR DESCRIPTION
Hi,

maybe I have overlooked something but I couldnt figure out what the Idea behind the `Methods` and `Options` maps in `ApiStruct` is. They are never looked up and just overwritten with the new `*Reponses`.

Using an API in an longrunning application, these could get quite big, I imagine.
