### PR TITLE
Api BaseUrl.Path is not honored by `do` method

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -172,10 +172,14 @@ func (r *Resource) Patch(options ...interface{}) (*Resource, error) {
 // Main method, opens the connection, sets basic auth, applies headers,
 // parses response json.
 func (r *Resource) do(method string) (*Resource, error) {
-	r.Api.BaseUrl.Path = r.Url
-	r.Api.BaseUrl.RawQuery = r.QueryValues.Encode()
-	url := r.Api.BaseUrl.String()
-	req, err := http.NewRequest(method, url, r.Payload)
+	url := *r.Api.BaseUrl
+	if len(url.Path) > 0 {
+		url.Path += "/" + r.Url
+	} else {
+		url.Path = r.Url
+	}
+	url.RawQuery = r.QueryValues.Encode()
+	req, err := http.NewRequest(method, url.String(), r.Payload)
 	if err != nil {
 		return r, err
 	}


### PR DESCRIPTION
I'm using `gopencils` like this:

```
res := gopencils.Api("http://host.name/path/to/api", nil)
res.Res("resname").Id("id123", &data).Get()
```

Before commit ce8e830 it was working perfectly and that code accesses
`http://host.name/path/to/api/resname/id123` URL.

After specified commit code will go to the `http://hostname/resname/id123`, which is incorrect, because of `Path` component of `r.Api.BaseUrl` gets overwritted by the resource URL.

Proposed path fixes that behavior, so resource URL will be added to the Api Path.
