### PR TITLE
fix SetQuery panic (caused by uninitialized map)

### DIFF
--- a/api.go
+++ b/api.go
@@ -69,5 +69,5 @@ func Api(baseUrl string, options ...interface{}) *Resource {
 		}
 		apiInstance.Client = client
 	}
-	return &Resource{Url: "", Api: apiInstance, QueryValues: make(url.Values)}
+	return &Resource{Url: "", Api: apiInstance}
 }

--- a/resource.go
+++ b/resource.go
@@ -83,6 +83,7 @@ func (r *Resource) Id(options ...interface{}) *Resource {
 
 // Sets QueryValues for current Resource
 func (r *Resource) SetQuery(querystring map[string]string) *Resource {
+	r.QueryValues = make(url.Values)
 	for k, v := range querystring {
 		r.QueryValues.Set(k, v)
 	}

--- a/resource_test.go
+++ b/resource_test.go
@@ -2,10 +2,11 @@ package gopencils
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (


### PR DESCRIPTION
`api.Res("someresource").SetQuery(query)` will panics. Caused by lost `UrlValues` map in call chain.

```
panic: runtime error: assignment to entry in nil map

goroutine 16 [running]:
runtime.panic(0x72f0c0, 0x93f753)
    /usr/lib/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/bndr/gopencils.(*Resource).SetQuery(0xc208004660, 0xc20807bc20, 0x2)
    /home/s.seletskiy/.go/src/github.com/bndr/gopencils/resource.go:87 +0x176
```
