### PR TITLE
Added Test for possible bug

### DIFF
--- a/resource_test.go
+++ b/resource_test.go
@@ -230,6 +230,17 @@ func TestDoNotDecodeBodyOnErr(t *testing.T) {
 	}
 }
 
+func TestNewResourceUrl(t *testing.T) {
+
+		api := Api("https://test-url.com")
+
+		res := api.Res("old")
+
+		newRes := res.Res("new")
+
+		assert.Equal(t, "new", newRes.Url, "new Resource should not be appended to old Url")
+}
+
 func readJson(path string) string {
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
I created a test to demo this, not sure if this is a bug or not

**Test Output**

```
--- FAIL: TestNewResourceUrl (0.00s)
        Error Trace:    resource_test.go:241
	Error:  	Not equal: "new" (expected)
			        != "old/new" (actual)
	Messages:	new Resource should not be appended to old Url
		
FAIL
```


Wanted to check it with you @bndr before creating a PR

Cheers,
Rob