### PR TITLE
close connection after reading the body

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -214,6 +214,8 @@ func (r *Resource) do(method string) (*Resource, error) {
 		return r, err
 	}
 
+	resp.Close = true
+
 	r.Raw = resp
 
 	if resp.StatusCode >= 400 {


### PR DESCRIPTION
This closes the connection after reading from the body, otherwise `too many open files` error pops up when making a lot of requests.

http://craigwickesser.com/2015/01/golang-http-to-many-open-files/

You can also read the godoc that refers to Response.Close property for details:
```

	// Close records whether the header directed that the connection be
	// closed after reading Body. The value is advice for clients: neither
	// ReadResponse nor Response.Write ever closes a connection.
	Close bool
```